### PR TITLE
Fixes problem in Get-NagiosXi functions with incorrect property name

### DIFF
--- a/Get-NagiosXiAllHostProblems.ps1
+++ b/Get-NagiosXiAllHostProblems.ps1
@@ -86,10 +86,10 @@ function Get-NagiosXiAllHostProblems {
         Write-Verbose 'Getting all Nagios XI host problems.'
         $AllHostProblems = Invoke-NagiosXIApi -NagiosXiApiUrl $NagiosXiApiUrl -Resource $Resource -Method $Method -Query $Query -NagiosXiApiKey $NagiosXiApiKey
         if ($Summary) {
-            $AllHostProblems.hoststatuslist.hoststatus | Select-Object -Property name, status_text, last_check
+            $AllHostProblems.hoststatus | Select-Object -Property name, status_text, last_check
         }
         else {
-            $AllHostProblems.hoststatuslist.hoststatus
+            $AllHostProblems.hoststatus
         }
         
     }

--- a/Get-NagiosXiAllOpenServiceProblems.ps1
+++ b/Get-NagiosXiAllOpenServiceProblems.ps1
@@ -91,10 +91,10 @@ function Get-NagiosXiAllOpenServiceProblems {
         $AllOpenServiceProblems = Invoke-NagiosXIApi -NagiosXiApiUrl $NagiosXiApiUrl -Resource $Resource -Method $Method -Query $Query -NagiosXiApiKey $NagiosXiApiKey
         if ($Summary) {
             Write-Verbose 'Summary Output selected.'
-            $AllOpenServiceProblems.servicestatuslist.servicestatus| Select-Object -Property host_name, name, status_text
+            $AllOpenServiceProblems.servicestatus| Select-Object -Property host_name, name, status_text
         }
         else {
-            $AllOpenServiceProblems.servicestatuslist.servicestatus
+            $AllOpenServiceProblems.servicestatus
         }
     }
     End {}

--- a/Get-NagiosXiAllServiceProblems.ps1
+++ b/Get-NagiosXiAllServiceProblems.ps1
@@ -90,10 +90,10 @@ function Get-NagiosXiAllServiceProblems {
         Write-Verbose 'Getting all Nagios XI service problems.'
         $AllServiceProblems = Invoke-NagiosXIApi -NagiosXiApiUrl $NagiosXiApiUrl -Resource $Resource -Method $Method -Query $Query -NagiosXiApiKey $NagiosXiApiKey
         if ($Summary) {
-            $AllServiceProblems.servicestatuslist.servicestatus | Select-Object -Property host_name, name, status_text
+            $AllServiceProblems.servicestatus | Select-Object -Property host_name, name, status_text
         }
         else {
-            $AllServiceProblems.servicestatuslist.servicestatus
+            $AllServiceProblems.servicestatus
         }
         
     }

--- a/Get-NagiosXiHostStatus.ps1
+++ b/Get-NagiosXiHostStatus.ps1
@@ -68,10 +68,10 @@ function Get-NagiosXiHostStatus {
         Write-Verbose "Query $Query"
         $HostStatus = Invoke-NagiosXIApi -NagiosXiApiUrl $NagiosXiApiUrl -Resource $Resource -Method $Method -Query $Query -NagiosXiApiKey $NagiosXiApiKey
         if ($Summary) {
-            $HostStatus.hoststatuslist.hoststatus | Select-Object -Property name, status_text, last_check
+            $HostStatus.hoststatus | Select-Object -Property name, status_text, last_check
         }
         else {
-            $HostStatus.hoststatuslist.hoststatus
+            $HostStatus.hoststatus
         }
         
     }

--- a/Get-NagiosXiOpenHostProblem.ps1
+++ b/Get-NagiosXiOpenHostProblem.ps1
@@ -85,10 +85,10 @@ function Get-NagiosXiOpenHostProblem {
         Write-Verbose 'Getting all Nagios XI host problems.'
         $OpenHostProblems = Invoke-NagiosXIApi -NagiosXiApiUrl $NagiosXiApiUrl -Resource $Resource -Method $Method -Query $Query -NagiosXiApiKey $NagiosXiApiKey
         if ($Summary) {
-            $OpenHostProblems.hoststatuslist.hoststatus | Select-Object -Property name, status_text, last_check
+            $OpenHostProblems.hoststatus | Select-Object -Property name, status_text, last_check
         }
         else {
-            $OpenHostProblems.hoststatuslist.hoststatus
+            $OpenHostProblems.hoststatus
         }
     }
     End {}

--- a/Get-NagiosXiServiceStatus.ps1
+++ b/Get-NagiosXiServiceStatus.ps1
@@ -110,10 +110,10 @@ function Get-NagiosXiServiceStatus {
         $ServiceStatus = Invoke-NagiosXIApi -NagiosXiApiUrl $NagiosXiApiUrl -Resource $Resource -Method $Method -Query $Query -NagiosXiApiKey $NagiosXiApiKey
         
         if ($Summary) {
-            $ServiceStatus.servicestatuslist.servicestatus | Select-Object -Property host_name, name, status_text
+            $ServiceStatus.servicestatus | Select-Object -Property host_name, name, status_text
         }
         else {
-            $ServiceStatus.servicestatuslist.servicestatus
+            $ServiceStatus.servicestatus
         }
     }
     End {}


### PR DESCRIPTION
As described in [this issue](https://github.com/wasserja/MrANagios/issues/4), the Get-NagiosXi* functions have a problem where a non-existing property is referenced. This makes that the functions will never report a result. 

I have made the changes and tested them against Nagios XI version 5.6.2. After the changes the functions return 

By the way, this is the first time I have contributed on Github and created a Pull Request. If I need to do things differently, please let me know. 